### PR TITLE
Compute wrapped chunk tickets by our own

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.7-SNAPSHOT'
+	id 'fabric-loom' version '1.8-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/src/main/java/com/fexl/circumnavigate/core/WrappedChunks.java
+++ b/src/main/java/com/fexl/circumnavigate/core/WrappedChunks.java
@@ -1,0 +1,109 @@
+package com.fexl.circumnavigate.core;
+
+import net.minecraft.server.level.*;
+import net.minecraft.world.level.ChunkPos;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+// TODO: Optimize, utilize more methods
+// This class should be thread safe and is used to keep track of which chunks are currently wrapped by players.
+public class WrappedChunks {
+
+    private final Map<Long, Set<ServerPlayer>> wrappedLoadedChunks; // uses long for easier comparison - less compute
+    public record ChunkLoad(Set<Long> chunksToLoad, Set<Long> chunksToUnload) {}
+
+    public WrappedChunks() {
+        this.wrappedLoadedChunks = new ConcurrentHashMap<>();
+    }
+
+    public boolean isPlayerInChunk(Long chunkPos) {
+        return wrappedLoadedChunks.containsKey(chunkPos) && !wrappedLoadedChunks.get(chunkPos).isEmpty();
+    }
+
+    public void loadChunk(ServerPlayer player, Long chunkPos, int ticketLevel) {
+        wrappedLoadedChunks.computeIfAbsent(chunkPos, k -> ConcurrentHashMap.newKeySet()).add(player);
+    }
+
+    public void unloadChunk(ServerPlayer player, Long chunkPos) {
+        wrappedLoadedChunks.computeIfPresent(chunkPos, (k, players) -> {
+            players.remove(player);
+            return players.isEmpty() ? null : players;
+        });
+    }
+
+    // should be called when player moves to other chunk / player connects
+    // returns a pair of list of chunks which should be loaded and list of chunks which can be unloaded due to player movement
+    public ChunkLoad playerMoved(@NotNull ServerPlayer player, int simulationDistance) {
+        Set<Long> chunksToUnload = ConcurrentHashMap.newKeySet();
+        Set<Long> chunksToLoad = ConcurrentHashMap.newKeySet();
+        Set<Long> occupiedChunks = getOccupiedChunks(player, simulationDistance);
+
+        // check which chunks should be loaded
+        occupiedChunks.stream()
+            .filter(chunkPos -> !wrappedLoadedChunks.containsKey(chunkPos))
+            .forEach(chunksToLoad::add);
+
+        // check which chunks should be unloaded
+        wrappedLoadedChunks.entrySet().stream()
+            .filter(entry -> !occupiedChunks.contains(entry.getKey()) && entry.getValue().size() == 1 && entry.getValue().contains(player))
+            .forEach(entry -> chunksToUnload.add(entry.getKey()));
+
+        return new ChunkLoad(chunksToLoad, chunksToUnload);
+    }
+
+    // should be called on player disconnect
+    public Set<Long> unloadAllPlayerChunks(@NotNull ServerPlayer player) {
+        Set<Long> chunksToUnload = new CopyOnWriteArraySet<>();
+        wrappedLoadedChunks.entrySet().stream()
+            .filter(entry -> entry.getValue().contains(player) && entry.getValue().size() == 1)
+            .forEach(entry -> chunksToUnload.add(entry.getKey()));
+        return chunksToUnload;
+    }
+
+    public Set<Long> getOccupiedChunks(@NotNull ServerPlayer player, int simulationDistance) {
+        ChunkPos chunkPos = player.chunkPosition();
+        WorldTransformer transformer = player.level().getTransformer();
+        ChunkPos wrappedChunkPos = transformer.translateChunkToBounds(chunkPos);
+
+        Map<Integer, Set<Long>> chunksPriority = new ConcurrentHashMap<>();
+
+        for (int i = 0; i <= simulationDistance; i++) {
+            int ticketLevel = getPlayerTicketLevel(i);
+            chunksPriority.putIfAbsent(ticketLevel, ConcurrentHashMap.newKeySet());
+
+            for (int x = -i; x <= i; x++) {
+                for (int z = -i; z <= i; z++) {
+                    ChunkPos currentChunkPos = new ChunkPos(wrappedChunkPos.x + x, wrappedChunkPos.z + z);
+                    ChunkPos wrappedCurrentChunkPos = transformer.translateChunkToBounds(currentChunkPos);
+                    long chunkPosLong = wrappedCurrentChunkPos.toLong();
+                    chunksPriority.get(ticketLevel).add(chunkPosLong);
+                }
+            }
+        }
+
+        Set<Long> occupiedChunks = new CopyOnWriteArraySet<>();
+        for (int i = 31; i >= 0; i--) {
+            if (chunksPriority.containsKey(i)) {
+                occupiedChunks.addAll(chunksPriority.get(i));
+            }
+        }
+
+        return occupiedChunks;
+    }
+
+    /**
+     * Determines the player ticket level based on the simulation distance.
+     * If the ticket level is 31 or lower, all ticks are processed.
+     * Took from {@link net.minecraft.server.level.DistanceManager#getPlayerTicketLevel()}
+     *
+     * @param simulationDistance the distance for simulation
+     * @return the player ticket level
+     * @see <a href="https://minecraft.wiki/w/Chunk#Level_and_load_type">Chunk Level and Load Type</a>
+     */
+    private int getPlayerTicketLevel(int simulationDistance) {
+        return Math.max(0, ChunkLevel.byStatus(FullChunkStatus.ENTITY_TICKING) - simulationDistance);
+    }
+}

--- a/src/main/java/com/fexl/circumnavigate/injected/LevelWrappedChunksInjector.java
+++ b/src/main/java/com/fexl/circumnavigate/injected/LevelWrappedChunksInjector.java
@@ -1,0 +1,13 @@
+package com.fexl.circumnavigate.injected;
+
+import com.fexl.circumnavigate.core.WrappedChunks;
+
+public interface LevelWrappedChunksInjector {
+    default WrappedChunks getWrappedChunks() {
+        return null;
+    }
+
+    default void setWrappedChunks(WrappedChunks wrappedChunks) {
+
+    }
+}

--- a/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/ChunkMapMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/ChunkMapMixin.java
@@ -6,12 +6,8 @@ import com.fexl.circumnavigate.core.WorldTransformer;
 import com.fexl.circumnavigate.storage.TransformerRequests;
 import net.minecraft.core.SectionPos;
 import net.minecraft.server.level.*;
-import net.minecraft.server.network.ServerPlayerConnection;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.phys.Vec3;
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -20,17 +16,9 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.List;
-import java.util.Set;
-
 @Mixin(ChunkMap.class)
 public abstract class ChunkMapMixin {
 	@Final @Shadow public ServerLevel level;
-	@Final @Shadow private ThreadedLevelLightEngine lightEngine;
-	@Final @Shadow private ChunkTaskPriorityQueueSorter queueSorter;
-	@Shadow abstract ChunkHolder updateChunkScheduling(long chunkPos, int newLevel, @Nullable ChunkHolder holder, int oldLevel);
-
-	ChunkMap thiz = (ChunkMap) (Object) this;
 
 	/**
 	 * Stores the serverLevel for usage further down the call chain where it was not passed.

--- a/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/ChunkTrackerMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/ChunkTrackerMixin.java
@@ -8,11 +8,9 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.server.level.ChunkTracker;
-import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.*;
 
-@Debug(export = true)
 @Mixin(ChunkTracker.class)
 public abstract class ChunkTrackerMixin {
 

--- a/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/ChunkTrackerMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/ChunkTrackerMixin.java
@@ -4,40 +4,63 @@ package com.fexl.circumnavigate.mixin.chunkHandle;
 
 import com.fexl.circumnavigate.storage.TransformerRequests;
 import com.fexl.circumnavigate.core.WorldTransformer;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.server.level.ChunkTracker;
-import net.minecraft.world.level.ChunkPos;
+import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.*;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+@Debug(export = true)
 @Mixin(ChunkTracker.class)
-public class ChunkTrackerMixin {
+public abstract class ChunkTrackerMixin {
 
+	// Is it yet needed?
 	/**
 	 * Updates loading levels of adjacent chunks so they are ready when needed. Modified to include wrapped chunks.
 	 */
-	@Inject(method = "checkNeighborsAfterUpdate", at = @At(value = "HEAD"), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
-	public void wrapppedChunkNeighbors(long pos, int level, boolean isDecreasing, CallbackInfo ci) {
-		ChunkTracker thiz = (ChunkTracker) (Object) this;
-		//TODO: Stop chunk access after bounds.
-		//ci.cancel();
+	@WrapOperation(method = "checkNeighborsAfterUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/ChunkPos;asLong(II)J"))
+	private long wrapChunkPos(int x, int z, Operation<Long> original, @Local(argsOnly = true) long pos, @Local(argsOnly = true) int level, @Local(argsOnly = true) boolean isDecreasing) {
 		WorldTransformer transformer = TransformerRequests.chunkCacheLevel.getTransformer();
 
-		if (isDecreasing && level >= thiz.levelCount - 2) {
-			return;
+		int wrappedX = transformer.xTransformer.wrapChunkToLimit(x);
+		int wrappedZ = transformer.zTransformer.wrapChunkToLimit(z);
+		long chunkLong = original.call(wrappedX, wrappedZ);
+		if (chunkLong != pos) {
+			ChunkTracker thiz = (ChunkTracker) (Object) this;
+			thiz.checkNeighbor(pos, chunkLong, level, isDecreasing);
 		}
-		ChunkPos chunkPos = new ChunkPos(pos);
-		int i = chunkPos.x;
-		int j = chunkPos.z;
-		for (int k = -1; k <= 1; ++k) {
-			for (int l = -1; l <= 1; ++l) {
-				long m = ChunkPos.asLong(transformer.xTransformer.wrapChunkToLimit(i + k), transformer.zTransformer.wrapChunkToLimit(j + l));
-				if (m == pos) continue;
-				thiz.checkNeighbor(pos, m, level, isDecreasing);
-			}
-		}
+
+		return original.call(x, z);
 	}
+
+
+// WrapOperation method above should be equivalent to the following commented out code.
+
+//	@Inject(method = "checkNeighborsAfterUpdate", at = @At(value = "HEAD"), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
+//	public void wrapppedChunkNeighbors(long pos, int level, boolean isDecreasing, CallbackInfo ci) {
+//		ChunkTracker thiz = (ChunkTracker) (Object) this;
+//		//TODO: Stop chunk access after bounds.
+//		//ci.cancel();
+//		WorldTransformer transformer = TransformerRequests.chunkCacheLevel.getTransformer();
+//
+//		if (isDecreasing && level >= thiz.levelCount - 2) {
+//			return;
+//		}
+//		ChunkPos chunkPos = new ChunkPos(pos);
+//		int i = chunkPos.x;
+//		int j = chunkPos.z;
+//		for (int k = -1; k <= 1; ++k) {
+//			for (int l = -1; l <= 1; ++l) {
+//				long m = ChunkPos.asLong(transformer.xTransformer.wrapChunkToLimit(i + k), transformer.zTransformer.wrapChunkToLimit(j + l));
+//				if (m == pos) continue;
+//				thiz.checkNeighbor(pos, m, level, isDecreasing);
+//			}
+//		}
+//	}
+//
+
 
 	/**
 	@Redirect(method = "checkNeighborsAfterUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/ChunkPos;asLong(II)J"))

--- a/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/DistanceManagerMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/DistanceManagerMixin.java
@@ -1,0 +1,45 @@
+package com.fexl.circumnavigate.mixin.chunkHandle;
+
+import com.fexl.circumnavigate.core.WrappedChunks;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import net.minecraft.core.SectionPos;
+import net.minecraft.server.level.DistanceManager;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.ChunkPos;
+import org.spongepowered.asm.mixin.*;
+
+@Mixin(DistanceManager.class)
+public abstract class DistanceManagerMixin {
+
+    @Shadow protected abstract void updateChunkForced(ChunkPos pos, boolean add);
+    @Shadow private int simulationDistance;
+
+    // those methods are called when player leaves/enters section, yet to further investigation.
+    @WrapMethod(method = "addPlayer")
+    private void addPlayerWrap(SectionPos sectionPos, ServerPlayer player, Operation<Void> original) {
+        original.call(sectionPos, player);
+        updateWrappedChunks(player);
+    }
+
+    @WrapMethod(method = "removePlayer")
+    private void removePlayerWrap(SectionPos sectionPos, ServerPlayer player, Operation<Void> original) {
+        original.call(sectionPos, player);
+        updateWrappedChunks(player);
+    }
+
+    // Fixes #10
+    @Unique
+    private void updateWrappedChunks(ServerPlayer player) {
+        WrappedChunks wrappedChunks = player.level().getWrappedChunks();
+        WrappedChunks.ChunkLoad chunkLoad = wrappedChunks.playerMoved(player, simulationDistance);
+
+        for (long chunk : chunkLoad.chunksToLoad()) {
+            updateChunkForced(new ChunkPos(chunk), true);
+        }
+
+        for (long chunk : chunkLoad.chunksToUnload()) {
+            updateChunkForced(new ChunkPos(chunk), false);
+        }
+    }
+}

--- a/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/ServerChunkCacheMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/ServerChunkCacheMixin.java
@@ -5,6 +5,7 @@ package com.fexl.circumnavigate.mixin.chunkHandle;
 import com.fexl.circumnavigate.storage.TransformerRequests;
 import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -12,8 +13,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ServerChunkCache.class)
-public class ServerChunkCacheMixin {
-	@Shadow ServerLevel level;
+public abstract class ServerChunkCacheMixin {
+	@Final @Shadow ServerLevel level;
 
 	/**
 	 * Stores the serverLevel for usage further down the call chain where it was not passed.

--- a/src/main/java/com/fexl/circumnavigate/mixin/interfaceInjects/LevelInjectorMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/interfaceInjects/LevelInjectorMixin.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.Unique;
  * Injects a transformer, wrappedChunks and accessor methods into Level instances. This means transformers and wrappedChunks are stored on a per-level basis.
  */
 @Mixin(Level.class)
-public class LevelTransformerInjectorMixin implements LevelTransformerInjector, LevelWrappedChunksInjector {
+public class LevelInjectorMixin implements LevelTransformerInjector, LevelWrappedChunksInjector {
 	@Unique
 	private WorldTransformer transformer = null;
 

--- a/src/main/java/com/fexl/circumnavigate/mixin/interfaceInjects/LevelTransformerInjectorMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/interfaceInjects/LevelTransformerInjectorMixin.java
@@ -2,21 +2,21 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-/* SPDX-License-Identifier: AGPL-3.0-only */
-
 package com.fexl.circumnavigate.mixin.interfaceInjects;
 
+import com.fexl.circumnavigate.core.WrappedChunks;
 import com.fexl.circumnavigate.injected.LevelTransformerInjector;
 import com.fexl.circumnavigate.core.WorldTransformer;
+import com.fexl.circumnavigate.injected.LevelWrappedChunksInjector;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
 /**
- * Injects a transformer and accessor methods into Level instances. This means transformers are stored on a per-level basis.
+ * Injects a transformer, wrappedChunks and accessor methods into Level instances. This means transformers and wrappedChunks are stored on a per-level basis.
  */
 @Mixin(Level.class)
-public class LevelTransformerInjectorMixin implements LevelTransformerInjector {
+public class LevelTransformerInjectorMixin implements LevelTransformerInjector, LevelWrappedChunksInjector {
 	@Unique
 	private WorldTransformer transformer = null;
 
@@ -30,5 +30,16 @@ public class LevelTransformerInjectorMixin implements LevelTransformerInjector {
 		this.transformer = transformer;
 	}
 
+	@Unique
+	private WrappedChunks wrappedChunks = null;
 
+	@Override
+	public WrappedChunks getWrappedChunks() {
+		return wrappedChunks;
+	}
+
+	@Override
+	public void setWrappedChunks(WrappedChunks wrappedChunks) {
+		this.wrappedChunks = wrappedChunks;
+	}
 }

--- a/src/main/java/com/fexl/circumnavigate/mixin/worldInit/ServerLevelMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/worldInit/ServerLevelMixin.java
@@ -2,12 +2,12 @@
 
 package com.fexl.circumnavigate.mixin.worldInit;
 
+import com.fexl.circumnavigate.core.WrappedChunks;
 import com.fexl.circumnavigate.options.WrappingSettings;
 import com.fexl.circumnavigate.core.WorldTransformer;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.*;
 import net.minecraft.server.level.progress.ChunkProgressListener;
 import net.minecraft.world.RandomSequences;
 import net.minecraft.world.level.Level;
@@ -23,14 +23,16 @@ import java.util.List;
 import java.util.concurrent.Executor;
 
 @Mixin(ServerLevel.class)
-public class ServerLevelMixin {
-	ServerLevel thiz = (ServerLevel) (Object) this;
+public abstract class ServerLevelMixin {
 
 	/**
-	 * Set the wrapping settings for each level when it is created
+	 * Set the wrapping settings for each level when it is created as quickly as possible.
 	 */
-	@Inject(method = "<init>(Lnet/minecraft/server/MinecraftServer;Ljava/util/concurrent/Executor;Lnet/minecraft/world/level/storage/LevelStorageSource$LevelStorageAccess;Lnet/minecraft/world/level/storage/ServerLevelData;Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/world/level/dimension/LevelStem;Lnet/minecraft/server/level/progress/ChunkProgressListener;ZJLjava/util/List;ZLnet/minecraft/world/RandomSequences;)V", at = @At("TAIL"))
+	@Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/dimension/LevelStem;generator()Lnet/minecraft/world/level/chunk/ChunkGenerator;"))
 	public void init(MinecraftServer server, Executor dispatcher, LevelStorageSource.LevelStorageAccess levelStorageAccess, ServerLevelData serverLevelData, ResourceKey dimension, LevelStem levelStem, ChunkProgressListener progressListener, boolean isDebug, long biomeZoomSeed, List customSpawners, boolean tickTime, RandomSequences randomSequences, CallbackInfo ci) {
+
+		ServerLevel thiz = (ServerLevel) (Object) this;
+
 		if(dimension.equals(Level.OVERWORLD)) {
 			thiz.setTransformer(new WorldTransformer(WrappingSettings.getXChunkBoundMin(), WrappingSettings.getXChunkBoundMax(), WrappingSettings.getZChunkBoundMin(), WrappingSettings.getZChunkBoundMax(), WrappingSettings.getXShift(),  WrappingSettings.getZShift()));
 		}
@@ -40,5 +42,7 @@ public class ServerLevelMixin {
 		else {
 			thiz.setTransformer(new WorldTransformer(WrappingSettings.invalidPos));
 		}
+
+		thiz.setWrappedChunks(new WrappedChunks());
 	}
 }

--- a/src/main/resources/circumnavigate.mixins.json
+++ b/src/main/resources/circumnavigate.mixins.json
@@ -33,7 +33,7 @@
     "entityHandle.collisions.LevelMixin",
     "entityHandle.entities.FishingHookMixin",
     "entityHandle.entities.vehicle.AbstractMinecartMixin",
-    "interfaceInjects.LevelTransformerInjectorMixin",
+    "interfaceInjects.LevelInjectorMixin",
     "interfaceInjects.PathNavigationRegionInjectorMixin",
     "interfaceInjects.PlayerClientInjectorMixin",
     "interfaceInjects.WorldGenRegionInjectorMixin",

--- a/src/main/resources/circumnavigate.mixins.json
+++ b/src/main/resources/circumnavigate.mixins.json
@@ -5,7 +5,6 @@
   "mixins": [
     "ServerPlayerGameModeMixin",
     "ServerToClientListener",
-    "itemHandle.BlockItemMixin",
     "blockHandle.ExplosionMixin",
     "blockHandle.NeighborUpdatorMixin",
     "blockHandle.blocks.BaseRailBlockMixin",
@@ -14,6 +13,7 @@
     "chunkHandle.ChunkMapMixin",
     "chunkHandle.ChunkTrackerMixin",
     "chunkHandle.ChunkTrackingViewMixin",
+    "chunkHandle.DistanceManagerMixin",
     "chunkHandle.PositionedAccessorMixin",
     "chunkHandle.PositionedMixin",
     "chunkHandle.SectionTrackerMixin",
@@ -37,6 +37,7 @@
     "interfaceInjects.PathNavigationRegionInjectorMixin",
     "interfaceInjects.PlayerClientInjectorMixin",
     "interfaceInjects.WorldGenRegionInjectorMixin",
+    "itemHandle.BlockItemMixin",
     "lightHandle.BlockLightEngineMixin",
     "lightHandle.LightEngineAccessor",
     "lightHandle.SkyLightEngineMixin",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
     "custom": {
       "loom:injected_interfaces": {
         "net/minecraft/class_3222": ["com/fexl/circumnavigate/injected/ServerPlayerInjector"],
-        "net/minecraft/class_1937": ["com/fexl/circumnavigate/injected/LevelTransformerInjector"],
+        "net/minecraft/class_1937": ["com/fexl/circumnavigate/injected/LevelTransformerInjector", "com/fexl/circumnavigate/injected/LevelWrappedChunksInjector"],
         "net/minecraft/class_1922": ["com/fexl/circumnavigate/injected/LevelTransformerInjector", "com/fexl/circumnavigate/injected/IsClientSideInjector"],
         "net/minecraft/class_1924": ["com/fexl/circumnavigate/injected/LevelTransformerInjector"]
       }
@@ -44,7 +44,7 @@
       }
 	],
 	"depends": {
-		"fabricloader": ">=0.15.7",
+		"fabricloader": ">=0.16.9",
 		"minecraft": "1.20.4",
 		"java": ">=17",
 		"fabric-api": "*"


### PR DESCRIPTION
Added `WrappedChunks` class per level, which calculates and manages chunk tickets for wrapped chunks.
Chunk ticket updates are called by `DistanceManagerMixin`. All tickets are level 31 (everything should be processed each tick) see [minecraft wiki](https://minecraft.wiki/w/Chunk#Level_and_load_type), theres also some code which calculates lower levels but it doesnt really change anything (wiki) so at the time being it is used to sort chunks if its near player it should load faster due to ticket being made first.
Not sure why i made it thread safe, you can change it.

Implementation is no near perfect yet and will require further maintenance, however it already works pretty well.

Fixes #10
