### PR TITLE
Correct loading levels of chunks past bounds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.7-SNAPSHOT'
+	id 'fabric-loom' version '1.8-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/src/client/java/com/fexl/circumnavigate/mixin/client/debug/ChunkBorderRendererMixin.java
+++ b/src/client/java/com/fexl/circumnavigate/mixin/client/debug/ChunkBorderRendererMixin.java
@@ -6,9 +6,7 @@ import com.fexl.circumnavigate.CircumnavigateClient;
 import com.fexl.circumnavigate.core.WorldTransformer;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
-import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Font;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.debug.ChunkBorderRenderer;
@@ -24,8 +22,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.Arrays;
 
 /**
  * Changes the debug chunk borders so that they appear purple at the world borders.

--- a/src/main/java/com/fexl/circumnavigate/Circumnavigate.java
+++ b/src/main/java/com/fexl/circumnavigate/Circumnavigate.java
@@ -4,23 +4,21 @@ package com.fexl.circumnavigate;
 
 import com.fexl.circumnavigate.network.packet.ChunkLoadingLevelsPayload;
 import com.fexl.circumnavigate.network.packet.LevelWrappingPayload;
-import com.fexl.circumnavigate.network.packet.LevelWrappingRequest;
 import com.fexl.circumnavigate.storage.DebugInfo;
 import net.fabricmc.api.ModInitializer;
 
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
-import net.fabricmc.fabric.api.networking.v1.ServerConfigurationNetworking;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
-import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.level.ServerPlayer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import java.util.Arrays;
 import java.util.HashMap;
-
 
 public class Circumnavigate implements ModInitializer {
 	public static final String MOD_ID = "circumnavigate";
+	public static final Logger LOGGER = LogManager.getLogger(MOD_ID);
 
 	public static int tickCount = 0;
 	@Override
@@ -29,7 +27,7 @@ public class Circumnavigate implements ModInitializer {
 		PayloadTypeRegistry.playS2C().register(ChunkLoadingLevelsPayload.TYPE, ChunkLoadingLevelsPayload.STREAM_CODEC);
 
 		ServerTickEvents.END_SERVER_TICK.register((server -> {
-			if(tickCount > 10) {
+			if (tickCount++ >= 10) {
 				server.getAllLevels().forEach((serverLevel -> {
 					for(ServerPlayer player : serverLevel.players()) {
 						ServerPlayNetworking.send(player, new ChunkLoadingLevelsPayload(DebugInfo.chunkLoadingLevels));
@@ -37,9 +35,8 @@ public class Circumnavigate implements ModInitializer {
 				}));
 				DebugInfo.chunkLoadingLevels = new HashMap<>();
 				tickCount = 0;
-			}
-			else {
-				tickCount += 1;
+
+//				LOGGER.info("Sent chunk loading levels to all players");
 			}
 		}));
 	}

--- a/src/main/java/com/fexl/circumnavigate/core/WorldTransformer.java
+++ b/src/main/java/com/fexl/circumnavigate/core/WorldTransformer.java
@@ -4,6 +4,7 @@ package com.fexl.circumnavigate.core;
 
 import com.fexl.circumnavigate.options.WrappingSettings;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.SectionPos;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.phys.AABB;
@@ -177,7 +178,13 @@ public class WorldTransformer {
 		int returnZ = zTransformer.wrapChunkToLimit(chunkPos.z);
 
 		return new ChunkPos(returnX, returnZ);
+	}
 
+	public SectionPos translateSectionToBounds(SectionPos sectionPos) {
+		int returnX = xTransformer.wrapChunkToLimit(sectionPos.x());
+		int returnZ = zTransformer.wrapChunkToLimit(sectionPos.z());
+
+		return SectionPos.of(returnX, sectionPos.y(), returnZ);
 	}
 
 	public long translateChunkToBounds(long chunkPos) {

--- a/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/ChunkTrackerMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/ChunkTrackerMixin.java
@@ -2,48 +2,70 @@
 
 package com.fexl.circumnavigate.mixin.chunkHandle;
 
-import com.fexl.circumnavigate.storage.TransformerRequests;
 import com.fexl.circumnavigate.core.WorldTransformer;
+import com.fexl.circumnavigate.storage.TransformerRequests;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.server.level.ChunkTracker;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.lighting.DynamicGraphMinFixedPoint;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.*;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(ChunkTracker.class)
-public class ChunkTrackerMixin {
+public abstract class ChunkTrackerMixin extends DynamicGraphMinFixedPoint {
+
+	protected ChunkTrackerMixin(int firstQueuedLevel, int width, int height) {
+		super(firstQueuedLevel, width, height);
+	}
+
+	@Shadow protected abstract int computeLevelFromNeighbor(long startPos, long endPos, int startLevel);
+
+	/**
+	 * Modifies ChunkPos to use wrapped chunks. This is essentially what fixes #10.
+	 */
+	@WrapOperation(method = "getComputedLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ChunkTracker;computeLevelFromNeighbor(JJI)I"))
+	private int getComputedLevel(ChunkTracker instance, long startPos, long endPos, int startLevel, Operation<Integer> original, @Local(name = "excludedSourcePos") long excludedSourcePos) {
+		int originalRet = original.call(instance, startPos, endPos, startLevel);
+
+		WorldTransformer transformer = TransformerRequests.chunkCacheLevel.getTransformer();
+
+		ChunkPos chunkPos = new ChunkPos(startPos);
+		ChunkPos wrappedChunkPos = transformer.translateChunkToBounds(chunkPos);
+		long wrappedPos = wrappedChunkPos.toLong();
+
+		if (wrappedPos == endPos) {
+			wrappedPos = ChunkPos.INVALID_CHUNK_POS;
+		}
+
+		if (wrappedPos != excludedSourcePos) {
+			int wrappedRet = this.computeLevelFromNeighbor(wrappedPos, endPos, getLevel(wrappedPos));
+
+			// return the lower of the two levels
+			return Math.min(originalRet, wrappedRet);
+		}
+
+		return originalRet;
+    }
 
 	/**
 	 * Updates loading levels of adjacent chunks so they are ready when needed. Modified to include wrapped chunks.
 	 */
-	@Inject(method = "checkNeighborsAfterUpdate", at = @At(value = "HEAD"), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
-	public void wrapppedChunkNeighbors(long pos, int level, boolean isDecreasing, CallbackInfo ci) {
-		ChunkTracker thiz = (ChunkTracker) (Object) this;
-		//TODO: Stop chunk access after bounds.
-		//ci.cancel();
+	@WrapOperation(method = "checkNeighborsAfterUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/ChunkPos;asLong(II)J"))
+	private long wrapChunkPos(int x, int z, Operation<Long> original, @Local(argsOnly = true) long pos, @Local(argsOnly = true) int level, @Local(argsOnly = true) boolean isDecreasing) {
 		WorldTransformer transformer = TransformerRequests.chunkCacheLevel.getTransformer();
 
-		if (isDecreasing && level >= thiz.levelCount - 2) {
-			return;
+		int wrappedX = transformer.xTransformer.wrapChunkToLimit(x);
+		int wrappedZ = transformer.zTransformer.wrapChunkToLimit(z);
+		long chunkLong = original.call(wrappedX, wrappedZ);
+
+		if (chunkLong != pos) {
+			ChunkTracker thiz = (ChunkTracker) (Object) this;
+			thiz.checkNeighbor(pos, chunkLong, level, isDecreasing);
 		}
-		ChunkPos chunkPos = new ChunkPos(pos);
-		int i = chunkPos.x;
-		int j = chunkPos.z;
-		for (int k = -1; k <= 1; ++k) {
-			for (int l = -1; l <= 1; ++l) {
-				long m = ChunkPos.asLong(transformer.xTransformer.wrapChunkToLimit(i + k), transformer.zTransformer.wrapChunkToLimit(j + l));
-				if (m == pos) continue;
-				thiz.checkNeighbor(pos, m, level, isDecreasing);
-			}
-		}
+
+		return original.call(x, z);
 	}
-
-	/**
-	@Redirect(method = "checkNeighborsAfterUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/ChunkPos;asLong(II)J"))
-	public long checkNeighborsAfterUpdate(int x, int z) {
-		WorldTransformer transformer = TransformerRequests.chunkCacheLevel.getTransformer();
-
-		return ChunkPos.asLong(transformer.xTransformer.wrapChunkToLimit(x), transformer.zTransformer.wrapChunkToLimit(z));
-	}**/
 }

--- a/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/ChunkTrackingViewMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/ChunkTrackingViewMixin.java
@@ -2,8 +2,8 @@
 
 package com.fexl.circumnavigate.mixin.chunkHandle;
 
-import com.fexl.circumnavigate.storage.TransformerRequests;
 import com.fexl.circumnavigate.core.WorldTransformer;
+import com.fexl.circumnavigate.storage.TransformerRequests;
 import net.minecraft.server.level.ChunkTrackingView;
 import net.minecraft.world.level.ChunkPos;
 import org.spongepowered.asm.mixin.Mixin;
@@ -37,7 +37,6 @@ public interface ChunkTrackingViewMixin extends ChunkTrackingView {
 		long n = m * m + l * l;
 		int k = viewDistance * viewDistance;
 		cir.setReturnValue(n < (long)k);
-
 	}
 
 	/**
@@ -86,7 +85,5 @@ public interface ChunkTrackingViewMixin extends ChunkTrackingView {
 
 		oldChunkTrackingView.forEach(chunkMarker);
 		newChunkTrackingView.forEach(chunkDropper);
-
 	}
-
 }

--- a/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/NaturalSpawnerMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/NaturalSpawnerMixin.java
@@ -17,8 +17,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(NaturalSpawner.class)
 public class NaturalSpawnerMixin {
+
 	@Inject(method = "spawnMobsForChunkGeneration", at = @At("HEAD"), cancellable = true)
 	private static void spawnMobsForChunkGeneration(ServerLevelAccessor levelAccessor, Holder<Biome> biome, ChunkPos chunkPos, RandomSource random, CallbackInfo ci) {
-		if(levelAccessor.getTransformer().isChunkOverBounds(chunkPos)) ci.cancel();
+		if (levelAccessor.getTransformer().isChunkOverBounds(chunkPos)) ci.cancel();
 	}
 }

--- a/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/PositionedAccessorMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/PositionedAccessorMixin.java
@@ -7,6 +7,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Mixin(Positioned.class)
-public abstract interface PositionedAccessorMixin {
-	@Invoker("squareIntersects") abstract boolean squareIntersectsAM(Positioned other);
+public interface PositionedAccessorMixin {
+	@Invoker("squareIntersects") boolean squareIntersectsAM(Positioned other);
 }

--- a/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/PositionedMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/PositionedMixin.java
@@ -6,21 +6,19 @@ import com.fexl.circumnavigate.storage.TransformerRequests;
 import com.fexl.circumnavigate.core.WorldTransformer;
 import net.minecraft.server.level.ChunkTrackingView.Positioned;
 import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.phys.Vec2;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Consumer;
 
 @Mixin(Positioned.class)
-public abstract  class PositionedMixin {
-	private Positioned thiz = (Positioned) (Object) this;
+public abstract class PositionedMixin {
+
+	@Unique private Positioned thiz = (Positioned) (Object) this;
 	/**
 	 * Modified to ensure when the player is on a chunk boundary, and login, they will get the correct chunks from both sides of the world. This method is only used on login.
 	 */
@@ -28,7 +26,6 @@ public abstract  class PositionedMixin {
 	private void includeWrappedChunks(Consumer<ChunkPos> action, CallbackInfo ci) {
 		ci.cancel();
 		WorldTransformer transformer = TransformerRequests.chunkMapLevel.getTransformer();
-
 
 		for (int x = thiz.minX(); x <= thiz.maxX(); x++) {
 			for (int z = thiz.minZ(); z <= thiz.maxZ(); z++) {

--- a/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/ServerChunkCacheMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/ServerChunkCacheMixin.java
@@ -5,6 +5,7 @@ package com.fexl.circumnavigate.mixin.chunkHandle;
 import com.fexl.circumnavigate.storage.TransformerRequests;
 import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ServerChunkCache.class)
 public class ServerChunkCacheMixin {
-	@Shadow ServerLevel level;
+	@Final @Shadow ServerLevel level;
 
 	/**
 	 * Stores the serverLevel for usage further down the call chain where it was not passed.

--- a/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/TrackedEntityMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/TrackedEntityMixin.java
@@ -4,25 +4,14 @@
 
 package com.fexl.circumnavigate.mixin.chunkHandle;
 
-import com.fexl.circumnavigate.core.WorldTransformer;
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.server.level.ChunkMap;
-import net.minecraft.server.level.ServerEntity;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.server.network.ServerPlayerConnection;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.Set;
 
 @Mixin(ChunkMap.TrackedEntity.class)
 public abstract class TrackedEntityMixin {
@@ -33,5 +22,4 @@ public abstract class TrackedEntityMixin {
 	public Vec3 unwrapVec(Vec3 playerPos, Vec3 entityPos, @Local(argsOnly = true) ServerPlayer player) {
 		return playerPos.subtract(player.level().getTransformer().translateVecFromBounds(playerPos, entityPos));
 	}
-
 }

--- a/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/generation/NoiseBasedChunkGeneratorMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/generation/NoiseBasedChunkGeneratorMixin.java
@@ -1,7 +1,6 @@
 package com.fexl.circumnavigate.mixin.chunkHandle.generation;
 
 import com.fexl.circumnavigate.accessors.LevelAccessor;
-import com.fexl.circumnavigate.core.WorldTransformer;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
@@ -17,6 +16,7 @@ import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
 import net.minecraft.world.level.levelgen.RandomState;
 import net.minecraft.world.level.levelgen.carver.ConfiguredWorldCarver;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -27,8 +27,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @SuppressWarnings("deprecation")
 @Mixin(NoiseBasedChunkGenerator.class)
 public class NoiseBasedChunkGeneratorMixin {
-    ServerLevel level;
-    ChunkPos chunkPos;
+    @Unique ServerLevel level;
+    @Unique ChunkPos chunkPos;
 
     @Inject(method = "applyCarvers", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/levelgen/WorldgenRandom;setLargeFeatureSeed(JII)V"))
     public void carveOverBoundsCancel(WorldGenRegion level, long seed, RandomState random, BiomeManager biomeManager, StructureManager structureManager, ChunkAccess chunk, GenerationStep.Carving step, CallbackInfo ci, @Local ConfiguredWorldCarver<?> configuredWorldCarver) {

--- a/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/generation/WorldGenContextMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/chunkHandle/generation/WorldGenContextMixin.java
@@ -18,6 +18,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(WorldGenContext.class)
 public class WorldGenContextMixin {
+
 	@Inject(method = "<init>", at = @At("TAIL"))
 	public void init(ServerLevel serverLevel, ChunkGenerator chunkGenerator, StructureTemplateManager structureTemplateManager, ThreadedLevelLightEngine threadedLevelLightEngine, ProcessorHandle processorHandle, CallbackInfo ci) {
 		((LevelAccessor) chunkGenerator).setLevel(serverLevel);

--- a/src/main/java/com/fexl/circumnavigate/mixin/interfaceInjects/LevelTransformerInjectorMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/interfaceInjects/LevelTransformerInjectorMixin.java
@@ -29,6 +29,4 @@ public class LevelTransformerInjectorMixin implements LevelTransformerInjector {
 	public void setTransformer(WorldTransformer transformer) {
 		this.transformer = transformer;
 	}
-
-
 }

--- a/src/main/java/com/fexl/circumnavigate/mixin/worldInit/ServerLevelMixin.java
+++ b/src/main/java/com/fexl/circumnavigate/mixin/worldInit/ServerLevelMixin.java
@@ -4,7 +4,6 @@ package com.fexl.circumnavigate.mixin.worldInit;
 
 import com.fexl.circumnavigate.options.WrappingSettings;
 import com.fexl.circumnavigate.core.WorldTransformer;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -24,13 +23,14 @@ import java.util.concurrent.Executor;
 
 @Mixin(ServerLevel.class)
 public class ServerLevelMixin {
-	ServerLevel thiz = (ServerLevel) (Object) this;
 
 	/**
-	 * Set the wrapping settings for each level when it is created
+	 * Set the wrapping settings for each level when it is created as quickly as possible.
 	 */
-	@Inject(method = "<init>(Lnet/minecraft/server/MinecraftServer;Ljava/util/concurrent/Executor;Lnet/minecraft/world/level/storage/LevelStorageSource$LevelStorageAccess;Lnet/minecraft/world/level/storage/ServerLevelData;Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/world/level/dimension/LevelStem;Lnet/minecraft/server/level/progress/ChunkProgressListener;ZJLjava/util/List;ZLnet/minecraft/world/RandomSequences;)V", at = @At("TAIL"))
+	@Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/dimension/LevelStem;generator()Lnet/minecraft/world/level/chunk/ChunkGenerator;"))
 	public void init(MinecraftServer server, Executor dispatcher, LevelStorageSource.LevelStorageAccess levelStorageAccess, ServerLevelData serverLevelData, ResourceKey dimension, LevelStem levelStem, ChunkProgressListener progressListener, boolean isDebug, long biomeZoomSeed, List customSpawners, boolean tickTime, RandomSequences randomSequences, CallbackInfo ci) {
+		ServerLevel thiz = (ServerLevel) (Object) this;
+
 		if(dimension.equals(Level.OVERWORLD)) {
 			thiz.setTransformer(new WorldTransformer(WrappingSettings.getXChunkBoundMin(), WrappingSettings.getZChunkBoundMin(), WrappingSettings.getXChunkBoundMax(), WrappingSettings.getZChunkBoundMax(), WrappingSettings.getXShift(),  WrappingSettings.getZShift()));
 		}

--- a/src/main/java/com/fexl/circumnavigate/storage/TransformerRequests.java
+++ b/src/main/java/com/fexl/circumnavigate/storage/TransformerRequests.java
@@ -2,9 +2,7 @@
 
 package com.fexl.circumnavigate.storage;
 
-import com.fexl.circumnavigate.core.WorldTransformer;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.Level;
 
 /**
  * Storage for context propagation down call stacks.

--- a/src/main/resources/circumnavigate.accesswidener
+++ b/src/main/resources/circumnavigate.accesswidener
@@ -80,4 +80,3 @@ accessible field net/minecraft/server/level/ChunkMap$TrackedEntity entity Lnet/m
 accessible class net/minecraft/server/level/ChunkMap$DistanceManager
 accessible method net/minecraft/server/level/DistanceManager removePlayer (Lnet/minecraft/core/SectionPos;Lnet/minecraft/server/level/ServerPlayer;)V
 accessible method net/minecraft/server/level/DistanceManager addPlayer (Lnet/minecraft/core/SectionPos;Lnet/minecraft/server/level/ServerPlayer;)V
-

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,19 +29,19 @@
 	},
     "accessWidener": "circumnavigate.accesswidener",
     "custom": {
-      "loom:injected_interfaces": {
-        "net/minecraft/class_3222": ["com/fexl/circumnavigate/injected/ServerPlayerInjector"],
-        "net/minecraft/class_1937": ["com/fexl/circumnavigate/injected/LevelTransformerInjector"],
-        "net/minecraft/class_1922": ["com/fexl/circumnavigate/injected/LevelTransformerInjector", "com/fexl/circumnavigate/injected/IsClientSideInjector"],
-        "net/minecraft/class_1924": ["com/fexl/circumnavigate/injected/LevelTransformerInjector"]
-      }
+      	"loom:injected_interfaces": {
+        	"net/minecraft/class_3222": ["com/fexl/circumnavigate/injected/ServerPlayerInjector"],
+        	"net/minecraft/class_1937": ["com/fexl/circumnavigate/injected/LevelTransformerInjector"],
+        	"net/minecraft/class_1922": ["com/fexl/circumnavigate/injected/LevelTransformerInjector", "com/fexl/circumnavigate/injected/IsClientSideInjector"],
+        	"net/minecraft/class_1924": ["com/fexl/circumnavigate/injected/LevelTransformerInjector"]
+      	}
     },
 	"mixins": [
 		"circumnavigate.mixins.json",
-      {
-        "config": "circumnavigate-client.mixins.json",
-        "environment": "client"
-      }
+		{
+			"config": "circumnavigate-client.mixins.json",
+			"environment": "client"
+		}
 	],
 	"depends": {
 		"fabricloader": ">=0.16.9",


### PR DESCRIPTION
`getComputedLevel` method in `ChunkTracker` has been corrected to get lower (correct) loading level of chunk
~~Currently randomly breaks chunk loading past bounds (no idea why maybe i made some typo please send help...)
Note: it really looks just like server would not send those chunks to client since they are loaded with level of 31 under f3 + g and also other player may stand in the same place and see these chunks normally~~ Looks like its already present in [#1817f47](https://github.com/FamroFexl/Circumnavigate/commit/1817f47388809c30d75465815b17cdb41afbb8f1)

Also smaller fixes, improvements to some mixins for better performance without changing the output.

Update fabric loom to 1.8

Fixes #10